### PR TITLE
Support dinamically created queues

### DIFF
--- a/src/safetyvalve_app.erl
+++ b/src/safetyvalve_app.erl
@@ -12,16 +12,15 @@
 start(_StartType, _StartArgs) ->
     {ok, MainPid} = safetyvalve_sup:start_link(),
 
-    {ok, Queues} = application:get_env(safetyvalve, queues),
-    
-    [ok = start_queue(Q) || Q <- Queues],
-    {ok, MainPid}.
-    
-stop(_State) ->
-    ok.
+    %% empty static queue definition is allowed
+    Queues = case application:get_env(safetyvalve, queues, undefined) of
+                undefined -> [];
+                Qs -> Qs
+             end,
 
-%% ----------------------------------------------------------------------
-start_queue({QName, Conf}) ->
-    lager:info("Safetyvalve starting up queue: ~p", [QName]),
-    {ok, _Pid} = safetyvalve_sup:start_queue(QName, Conf),
+    %% launch statically configured queues
+    [{ok, _QueuePid} = sv:new(Name, Conf) || {Name, Conf} <- Queues],
+    {ok, MainPid}.
+
+stop(_State) ->
     ok.

--- a/src/safetyvalve_sup.erl
+++ b/src/safetyvalve_sup.erl
@@ -4,14 +4,10 @@
 -behaviour(supervisor).
 
 %% API
--export([start_link/0, start_queue/2]).
+-export([start_link/0, start_queue/2, stop_queue/1]).
 
 %% Supervisor callbacks
 -export([init/1]).
-
-%% Helper macro for declaring children of supervisor
--define(QCHILD(I, C, Type), {I, {sv_queue, start_link, [I, C]},
-                             permanent, 5000, Type, [I]}).
 
 %% ===================================================================
 %% API functions
@@ -20,15 +16,37 @@
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
-start_queue(Name, Conf) ->
+-spec start_queue(Queue, Conf) -> {ok, pid()} | {error, invalid_configuration}
+        when
+            Queue :: undefined | atom(),
+             Conf :: proplists:proplist().
+start_queue(Queue, Conf) ->
     C = sv_queue:parse_configuration(Conf),
-    supervisor:start_child(?MODULE,
-                           ?QCHILD(Name, C, worker)).
+    case supervisor:start_child(?MODULE, [Queue, C]) of
+        {ok, Pid} -> {ok, Pid};
+        {error, {already_started, Pid}} ->
+            %% a process is already running registered with the
+            %% provided name, we must now obtain it's current
+            %% configuration and check that it is indeed the same
+            case sv_queue:q(Pid, configuration) of
+                C -> {ok, Pid};
+                _ -> {error, invalid_configuration}
+            end
+    end.
+
+-spec stop_queue(Queue) -> ok | {error, not_found | simple_one_for_one}
+    when
+        Queue :: undefined | atom().
+stop_queue(Queue) when is_pid(Queue) ->
+    supervisor:terminate_child(?MODULE, Queue);
+stop_queue(Queue) when is_atom(Queue) ->
+    supervisor:terminate_child(?MODULE, whereis(Queue)).
 
 %% ===================================================================
 %% Supervisor callbacks
 %% ===================================================================
 
 init([]) ->
-    {ok, { {one_for_one, 3, 600}, []} }.
-
+    {ok, { {simple_one_for_one, 3, 600},
+        [{queue, {sv_queue, start_link, []},
+          transient, 5000, worker, [sv_queue]}] } }.


### PR DESCRIPTION
introduce sv:new/2, new/1 methods that allow dynamic
creation of named or anomymous queues, each with a
separate configuration