### PR TITLE
Make compatible as a dep for erlang.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ ERLC_OPTS = +debug_info '+{parse_transform, lager_transform}'
 DEPS = lager
 dep_lager = http://github.com/basho/lager.git 2.0.3
 
-eqc-ci: all
-	erlc -o ebin eqc_test/svq.erl
-
 include erlang.mk
 
+eqc-ci: all
+	erlc -o ebin eqc_test/svq.erl


### PR DESCRIPTION
Default target should build the project without requiring to have EQC installed.