### PR TITLE
Add missing pid spec argument to destroy method

### DIFF
--- a/src/safetyvalve_sup.erl
+++ b/src/safetyvalve_sup.erl
@@ -36,7 +36,7 @@ start_queue(Queue, Conf) ->
 
 -spec stop_queue(Queue) -> ok | {error, not_found | simple_one_for_one}
     when
-        Queue :: undefined | atom().
+        Queue :: undefined | pid() | atom().
 stop_queue(Queue) when is_pid(Queue) ->
     supervisor:terminate_child(?MODULE, Queue);
 stop_queue(Queue) when is_atom(Queue) ->

--- a/src/sv.erl
+++ b/src/sv.erl
@@ -25,7 +25,7 @@ new(Queue, Conf) ->
 %% @end
 -spec destroy(Queue) -> ok | {error, not_found | simple_one_for_one}
     when
-      Queue :: undefined | atom().
+      Queue :: undefined | pid() | atom().
 destroy(Queue) ->
     safetyvalve_sup:stop_queue(Queue).
 


### PR DESCRIPTION
It was missing these, pid type for the queue argument got introduced in #4 