### PR TITLE
Bump lager dependency; support rebar3 and 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ REBAR = rebar3
 ERLC_OPTS = +debug_info '+{parse_transform, lager_transform}'
 
 DEPS = lager
-dep_lager = http://github.com/basho/lager.git 2.0.3
+dep_lager = https://github.com/erlang-lager/lager.git 3.5.0
 
 include erlang.mk
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,7 @@
-{require_otp_vsn, "R15|R16|(17.*)|(18.*)"}.
 {erl_opts, [debug_info,
             {parse_transform, lager_transform}]}.
 
 {deps, [
-        {lager, ".*", {git, "https://github.com/basho/lager.git", {tag, "2.1.0"}}}
+        lager
        ]}.
 

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,10 @@
+case erlang:function_exported(rebar3, main, 1) of
+    true -> % rebar3
+        CONFIG;
+    false -> % rebar 2.x or older
+        %% Rebuild deps, possibly including those that have been moved to
+        %% profiles
+        [{deps, [
+	   {lager, ".*", {git, "https://github.com/erlang-lager/lager.git", {tag, "3.5.0"}}}
+        ]} | lists:keydelete(deps, 1, CONFIG)]
+end.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,8 @@
-[{<<"goldrush">>,
-  {git,"git://github.com/DeadZen/goldrush.git",
-       {ref,"71e63212f12c25827e0c1b4198d37d5d018a7fec"}},
-  1},
- {<<"lager">>,
-  {git,"https://github.com/basho/lager.git",
-       {ref,"840acab51ebfb731de0137d9c6d41e7db4a12793"}},
-  0}].
+{"1.1.0",
+[{<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
+ {<<"lager">>,{pkg,<<"lager">>,<<"3.5.0">>},0}]}.
+[
+{pkg_hash,[
+ {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
+ {<<"lager">>, <<"C7D35985D784CCE9F8FA4056023CE873252B68BC31A81C63E4286857713DD6CE">>}]}
+].

--- a/src/safetyvalve.app.src
+++ b/src/safetyvalve.app.src
@@ -8,7 +8,10 @@
                   stdlib,
                   lager
                  ]},
-  {modules, []},                 
+  {modules, []},
   {mod, { safetyvalve_app, []}},
-  {env, []}
+  {env, []},
+  {maintainers, ["Jesper Louis Andersen"]},
+  {licenses, ["Apache 2"]},
+  {links, [{"Github", "https://github.com/jlouis/safetyvalve"}]}
  ]}.


### PR DESCRIPTION
This PR is intended to:

- add support for OTP 19 and 20 (removing the restriction in the rebar.config file)
- update the github url location for lager in both erlang.mk and rebar3 config
- bump the version to the latest release
- retain support for rebar2
- add hex.pm publishing metadata